### PR TITLE
feat: Implement fetchBlockStatus and fix block height comparison bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bitcoinerlab/explorer",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/explorer",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "bitcoinjs-lib": "^6.1.3",
-        "electrum-client": "github:BlueWallet/rn-electrum-client#76c0ea35e1a50c47f3a7f818d529ebd100161496",
+        "electrum-client": "github:BlueWallet/rn-electrum-client#47acb51149e97fab249c3f8a314f708dbee4fb6e",
         "net": "^1.0.2",
         "tls": "^0.0.1"
       },
@@ -2656,8 +2656,8 @@
     },
     "node_modules/electrum-client": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/BlueWallet/rn-electrum-client.git#76c0ea35e1a50c47f3a7f818d529ebd100161496",
-      "integrity": "sha512-w9LHCQYUlCddBRGrDmgo1EUNp+zmzcyQSKLFOeO1XPITiAAFQDBZLwORVbBPywhMXf4PUk1dOphhHzJBJYG0vA==",
+      "resolved": "git+ssh://git@github.com/BlueWallet/rn-electrum-client.git#47acb51149e97fab249c3f8a314f708dbee4fb6e",
+      "integrity": "sha512-u5KKZ1eMRPhi5jZB9l1pNUGN4SKVk+Cv0iCMvIaJOLYGabMzMY+lAVzOioxRIueqBvdQgM20kymw+T0JTw6GUQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7822,9 +7822,9 @@
       "dev": true
     },
     "electrum-client": {
-      "version": "git+ssh://git@github.com/BlueWallet/rn-electrum-client.git#76c0ea35e1a50c47f3a7f818d529ebd100161496",
-      "integrity": "sha512-w9LHCQYUlCddBRGrDmgo1EUNp+zmzcyQSKLFOeO1XPITiAAFQDBZLwORVbBPywhMXf4PUk1dOphhHzJBJYG0vA==",
-      "from": "electrum-client@github:BlueWallet/rn-electrum-client#76c0ea35e1a50c47f3a7f818d529ebd100161496"
+      "version": "git+ssh://git@github.com/BlueWallet/rn-electrum-client.git#47acb51149e97fab249c3f8a314f708dbee4fb6e",
+      "integrity": "sha512-u5KKZ1eMRPhi5jZB9l1pNUGN4SKVk+Cv0iCMvIaJOLYGabMzMY+lAVzOioxRIueqBvdQgM20kymw+T0JTw6GUQ==",
+      "from": "electrum-client@github:BlueWallet/rn-electrum-client#47acb51149e97fab249c3f8a314f708dbee4fb6e"
     },
     "emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/explorer",
   "description": "Bitcoin Blockchain Explorer: Client Interface featuring Esplora and Electrum Implementations.",
   "homepage": "https://github.com/bitcoinerlab/explorer",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "bitcoinjs-lib": "^6.1.3",
-    "electrum-client": "github:BlueWallet/rn-electrum-client#76c0ea35e1a50c47f3a7f818d529ebd100161496",
+    "electrum-client": "github:BlueWallet/rn-electrum-client#47acb51149e97fab249c3f8a314f708dbee4fb6e",
     "net": "^1.0.2",
     "tls": "^0.0.1"
   }

--- a/src/electrum-client.d.ts
+++ b/src/electrum-client.d.ts
@@ -39,5 +39,7 @@ declare module 'electrum-client' {
     blockchainEstimatefee(target: number): Promise<number>;
 
     blockchainTransaction_broadcast(txHex: string): Promise<string>;
+
+    blockchainBlock_header(height: number): Promise<string>;
   }
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -99,7 +99,17 @@ export interface Explorer {
   fetchFeeEstimates(): Promise<Record<string, number>>;
 
   /**
-   * Get's current block height.
+   * Get's the `BlockStatus: { blockHeight: number; blockHash: string; blockTime: number; }`)
+   * of a certain `blockHeight`.
+   *
+   * Returns `undefined` if this block height has not been mined yet.
+   * @async
+   * @returns `BlockStatus | undefined`;
+   */
+  fetchBlockStatus(blockHeight: number): Promise<BlockStatus | undefined>;
+
+  /**
+   * Get's current block height (blockchain tip).
    * @async
    * @returns A number representing the current height.
    */
@@ -114,3 +124,10 @@ export interface Explorer {
    */
   push(txHex: string): Promise<string>;
 }
+
+export type BlockStatus = {
+  blockHeight: number;
+  blockHash: string;
+  blockTime: number;
+  irreversible: boolean;
+};


### PR DESCRIPTION
### Changes
- Added fetchBlockStatus method to ElectrumExplorer for retrieving and caching block status information.
- Added fetchBlockStatus method to EsploraExplorer for retrieving and caching block status information.
- Updated unit tests to cover new fetchBlockStatus functionality.
- Updated dependencies in package.json.
- Bumped version to 0.2.0.

### Bug Fixes
- Fixed bug in EsploraExplorer block height comparison logic:
  - Previous code was incorrectly checking if the new block height was larger than the cache time.
  - Corrected to check if the new block height is larger than the last set block height.

### Testing
- Updated unit tests for the fetchBlockStatus method.
- All tests pass locally and on CI.