### PR TITLE
Implement and document isConnected method for Electrum and Esplora explorers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/explorer",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/explorer",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "bitcoinjs-lib": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/explorer",
   "description": "Bitcoin Blockchain Explorer: Client Interface featuring Esplora and Electrum Implementations.",
   "homepage": "https://github.com/bitcoinerlab/explorer",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/src/electrum.ts
+++ b/src/electrum.ts
@@ -220,6 +220,20 @@ export class ElectrumExplorer implements Explorer {
   }
 
   /**
+   * Implements {@link Explorer#isConnected}.
+   *  Checks server connectivity by sending a ping. Returns `true` if the ping
+   * is successful, otherwise `false`.
+   */
+  async isConnected(): Promise<boolean> {
+    if (this.#client === undefined) return false;
+    try {
+      await this.#client.server_ping();
+      return true;
+    } catch {}
+    return false;
+  }
+
+  /**
    * Implements {@link Explorer#close}.
    */
   async close(): Promise<void> {

--- a/src/esplora.ts
+++ b/src/esplora.ts
@@ -93,6 +93,18 @@ export class EsploraExplorer implements Explorer {
   async connect() {
     return;
   }
+  /**
+   * Implements {@link Explorer#isConnected}.
+   * Checks server connectivity by attempting to fetch the current block height.
+   * Returns `true` if successful, otherwise `false`.
+   */
+  async isConnected(): Promise<boolean> {
+    try {
+      await this.fetchBlockHeight();
+      return true;
+    } catch {}
+    return false;
+  }
   async close() {
     return;
   }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -26,6 +26,26 @@ export interface Explorer {
   connect(): Promise<void>;
 
   /**
+   * Checks if the connection to the server is alive.
+   *
+   * For the Electrum client, this method directly checks the server's
+   * availability by sending a ping.
+   * It returns `true` if the ping is successful, otherwise `false`.
+   *
+   * For the Esplora client, this method checks the server's availability by
+   * attempting to fetch the current block height.
+   * Note that the Esplora client returns `true` even after closing the
+   * connection, because an HTTP connection is stateless and not persistent.
+   * Thus, for Esplora, `isConnected` effectively checks if the server can
+   * respond to requests.
+   *
+   * @async
+   * @returns {Promise<boolean>} Promise resolving to `true` if the server is
+   * reachable and responding; otherwise, `false`.
+   */
+  isConnected(): Promise<boolean>;
+
+  /**
    * Close the connection.
    * @async
    */

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -105,6 +105,9 @@ for (const regtestExplorer of regtestExplorers) {
     test(`Connect`, async () => {
       await expect(explorer.connect()).resolves.not.toThrow();
     });
+    test(`isConnected`, async () => {
+      await expect(explorer.isConnected()).resolves.toBe(true);
+    });
 
     test('fetchAddress', async () => {
       expect({
@@ -246,7 +249,8 @@ describe('Explorer: Tests with public servers', () => {
         }
       } else throw new Error('Please, pass a correct service');
       await expect(explorer.connect()).resolves.not.toThrow();
-    });
+      await expect(explorer.isConnected()).resolves.toBe(true);
+    }, 10000);
     ////As of May 19th, 2023, 19iqYbeATe4RxghQZJnYVFU4mjUUu76EA6 has > 90K txs
     ////electrum (depending on the server): history too large / server busy - request timed out
     ////esplora will: Too many transactions per address


### PR DESCRIPTION
### Changes Introduced
- **Functionality**: The `isConnected` method has been implemented for both the Electrum and Esplora explorers.  For Electrum, it involves sending a ping to the server, while Esplora fetches the current block height.
  
- **Documentation**: Updated the `Explorer` interface documentation to include detailed descriptions of the `isConnected` method.

- **Testing**: Added new tests in `explorer.test.ts` to ensure that `isConnected` behaves as expected across both implementations.

- **Version Update**: Updated the version in `package.json` and `package-lock.json` from `0.2.2` to `0.2.3`, preparing for a new minor release that introduces the new feature.
