### PR TITLE
Refactor RequestQueue and Expose in EsploraExplorer Constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/explorer",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/explorer",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "bitcoinjs-lib": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/explorer",
   "description": "Bitcoin Blockchain Explorer: Client Interface featuring Esplora and Electrum Implementations.",
   "homepage": "https://github.com/bitcoinerlab/explorer",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,13 @@
+//regtest
+export const ESPLORA_LOCAL_REGTEST_URL = 'http://127.0.0.1:3002';
+export const ELECTRUM_LOCAL_REGTEST_HOST = '127.0.0.1';
+export const ELECTRUM_LOCAL_REGTEST_PORT = 60401;
+export const ELECTRUM_LOCAL_REGTEST_PROTOCOL = 'tcp';
+
+//blockstream
 export const ESPLORA_BLOCKSTREAM_URL = 'https://blockstream.info/api';
 export const ESPLORA_BLOCKSTREAM_TESTNET_URL =
   'https://blockstream.info/testnet/api';
-export const ESPLORA_LOCAL_REGTEST_URL = 'http://127.0.0.1:3002';
 
 export const ELECTRUM_BLOCKSTREAM_HOST = 'electrum.blockstream.info';
 export const ELECTRUM_BLOCKSTREAM_PORT = 50002;
@@ -11,6 +17,17 @@ export const ELECTRUM_BLOCKSTREAM_TESTNET_HOST = 'electrum.blockstream.info';
 export const ELECTRUM_BLOCKSTREAM_TESTNET_PORT = 60002;
 export const ELECTRUM_BLOCKSTREAM_TESTNET_PROTOCOL = 'ssl';
 
-export const ELECTRUM_LOCAL_REGTEST_HOST = '127.0.0.1';
-export const ELECTRUM_LOCAL_REGTEST_PORT = 60401;
-export const ELECTRUM_LOCAL_REGTEST_PROTOCOL = 'tcp';
+//mempool space
+export const ESPLORA_MEMPOOLSPACE_URL = 'https://mempool.space/api';
+export const ESPLORA_MEMPOOLSPACE_TESTNET_URL =
+  'https://mempool.space/testnet/api';
+
+//Not available
+//export const ELECTRUM_MEMPOOLSPACE_HOST = 'mempool.space';
+//export const ELECTRUM_MEMPOOLSPACE_PORT = 50002;
+//export const ELECTRUM_MEMPOOLSPACE_PROTOCOL = 'ssl';
+
+//Not available
+//export const ELECTRUM_MEMPOOLSPACE_TESTNET_HOST = 'electrum.mempool.space';
+//export const ELECTRUM_MEMPOOLSPACE_TESTNET_PORT = 60002;
+//export const ELECTRUM_MEMPOOLSPACE_TESTNET_PROTOCOL = 'ssl';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
-import type { Explorer } from './interface';
+import type { Explorer, BlockStatus } from './interface';
 import { EsploraExplorer } from './esplora';
+import type { RequestQueueParams } from './requestQueue';
 import { ElectrumExplorer } from './electrum';
 export * from './constants';
-export { Explorer, EsploraExplorer, ElectrumExplorer };
+export {
+  Explorer,
+  EsploraExplorer,
+  ElectrumExplorer,
+  BlockStatus,
+  RequestQueueParams
+};

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -232,9 +232,11 @@ describe('Explorer: Tests with public servers', () => {
     let explorer: Explorer;
     const explorerName =
       server.service + ' on ' + (server.host || 'default host');
-    test(`Create and connect to ${server.service} on ${
-      server.service === ELECTRUM ? server.host : server.url
-    }`, async () => {
+    const hostOrUrl =
+      server.service === ELECTRUM
+        ? server.host || 'default Electrum host'
+        : server.url || 'default Esplora host';
+    test(`Create and connect to ${server.service} on ${hostOrUrl}`, async () => {
       if (server.service === ELECTRUM) {
         try {
           explorer = new ElectrumExplorer(server);
@@ -250,7 +252,7 @@ describe('Explorer: Tests with public servers', () => {
       } else throw new Error('Please, pass a correct service');
       await expect(explorer.connect()).resolves.not.toThrow();
       await expect(explorer.isConnected()).resolves.toBe(true);
-    }, 10000);
+    }, 30000);
     ////As of May 19th, 2023, 19iqYbeATe4RxghQZJnYVFU4mjUUu76EA6 has > 90K txs
     ////electrum (depending on the server): history too large / server busy - request timed out
     ////esplora will: Too many transactions per address
@@ -285,7 +287,7 @@ describe('Explorer: Tests with public servers', () => {
           );
         prevIndex = index;
       }
-    }, 30000);
+    }, 60000);
     test(`fetchBlockStatus using ${explorerName}`, async () => {
       const blockStatus = await explorer.fetchBlockStatus(847612);
       expect(blockStatus?.blockTime).toBe(1718187771);

--- a/test/fixtures/explorer.ts
+++ b/test/fixtures/explorer.ts
@@ -80,10 +80,11 @@ export const fixtures = {
         protocol: 'ssl'
       },
       {
-        //will default to blockstream electrum
+        //will default to blockstream or mempool.space electrum
         service: ELECTRUM
       },
       {
+        //will default to blockstream or mempool.space esplora
         service: ESPLORA
       }
     ]


### PR DESCRIPTION
### Overview
This PR introduces a major refactor of the `RequestQueue` and exposes it as a configurable parameter in the `EsploraExplorer` constructor. The changes aim to improve error handling and provide more control over request queue management in Esplora clients.

### Key Changes
1. **RequestQueue Refactor**:
   - Added checks and thresholds for soft errors (HTTP 429, 50x) and hard errors.
   - Implemented a conservative approach by preventing new tasks from being added to the queue while handling errors.
   - Introduced parameters for configuring the RequestQueue, including:
     - `maxAttemptsForSoftErrors`
     - `maxAttemptsForHardErrors`
   - Added a function to generate randomized throttle times to avoid synchronized retry attempts.

2. **EsploraExplorer Constructor**:
   - Updated the `EsploraExplorer` constructor to accept `RequestQueueParams`.
   - Integrated the refactored `RequestQueue` into the `EsploraExplorer` instance.

3. **Configuration Updates**:
   - Adjusted constants and configuration for regtest, blockstream, and mempool space environments.

4. **Tests and Fixtures**:
   - Enhanced test coverage.

5. **Version Bump**:
   - Updated package version to `0.3.0` to reflect the significant internal changes and improvements.
