### PR TITLE
feat: API improvements and reconnection fixes for Electrum explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ import { EsploraExplorer } from '@bitcoinerlab/explorer';
   const feeEstimates = await explorer.fetchFeeEstimates();
 
   // Close the connection
-  await explorer.close();
+  explorer.close();
 })();
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/explorer",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/explorer",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/electrum-client": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/explorer",
   "description": "Bitcoin Blockchain Explorer: Client Interface featuring Esplora and Electrum Implementations.",
   "homepage": "https://github.com/bitcoinerlab/explorer",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/src/esplora.ts
+++ b/src/esplora.ts
@@ -26,6 +26,7 @@ function isValidHttpUrl(string: string): boolean {
  * Implements an {@link Explorer} Interface for an Esplora server.
  */
 export class EsploraExplorer implements Explorer {
+  #closed: boolean = true;
   #timeout: number;
   #irrevConfThresh: number;
   #BLOCK_HEIGHT_CACHE_TIME: number = 3; //cache for 3 seconds at most
@@ -64,6 +65,7 @@ export class EsploraExplorer implements Explorer {
     this.#url = url;
     this.#irrevConfThresh = irrevConfThresh;
     this.#maxTxPerScriptPubKey = maxTxPerScriptPubKey;
+    this.#closed = true;
   }
 
   async #esploraFetch(...args: Parameters<typeof fetch>): Promise<Response> {
@@ -123,6 +125,7 @@ export class EsploraExplorer implements Explorer {
   }
 
   async connect() {
+    this.#closed = false;
     return;
   }
   /**
@@ -130,18 +133,18 @@ export class EsploraExplorer implements Explorer {
    * Checks server connectivity by attempting to fetch the current block height.
    * Returns `true` if successful, otherwise `false`.
    */
-  async isConnected(
-    requestNetworkConfirmation: boolean = true
-  ): Promise<boolean> {
-    if (requestNetworkConfirmation) {
-      try {
-        await this.fetchBlockHeight();
-        return true;
-      } catch {}
-      return false;
-    } else return true;
+  async isConnected(): Promise<boolean> {
+    try {
+      await this.fetchBlockHeight();
+      return true;
+    } catch {}
+    return false;
   }
-  async close() {
+  isClosed(): boolean {
+    return this.#closed;
+  }
+  close() {
+    this.#closed = true;
     return;
   }
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -40,17 +40,21 @@ export interface Explorer {
    * respond to requests.
    *
    * @async
-   * @param {boolean} [requestNetworkConfirmation=true] When `true`, this checks the network to confirm if the connection is active. When `false`, it only verifies that all required initializations, like calling `connect()` for Electrum clients, have been completed.
    * @returns {Promise<boolean>} Promise resolving to `true` if the server is
    * reachable and responding; otherwise, `false`.
    */
-  isConnected(requestNetworkConfirmation?: boolean): Promise<boolean>;
+  isConnected(): Promise<boolean>;
+
+  /**
+   * Returns true if connect has never been called
+   * or if close() was called after a connect().
+   */
+  isClosed(): boolean;
 
   /**
    * Close the connection.
-   * @async
    */
-  close(): Promise<void>;
+  close(): void;
 
   /**
    * Get the balance of an address and find out whether the address ever

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -221,8 +221,8 @@ for (const regtestExplorer of regtestExplorers) {
         ) //Push a problematic tx that has "Missing inputs"
       ).rejects.toThrow(/bad-txns-inputs-missingorspent/);
     });
-    test('close', async () => {
-      await explorer.close();
+    test('close', () => {
+      explorer.close();
     });
   });
 }
@@ -300,8 +300,8 @@ describe('Explorer: Tests with public servers', () => {
       const blockStatus2 = await explorer.fetchBlockStatus(847612);
       expect(blockStatus2).toBe(blockStatus); // Checks reference equality
     }, 30000);
-    test(`close ${explorerName}`, async () => {
-      await explorer.close();
+    test(`close ${explorerName}`, () => {
+      explorer.close();
       //await new Promise(r => setTimeout(r, 9000));
     }, 10000);
   }


### PR DESCRIPTION
refactor: update API with `isClosed` method and remove `requestNetworkConfirmation` flag

- Added `isClosed` method to the `Explorer` interface and its implementations (`ElectrumExplorer`, `EsploraExplorer`).
- Removed `requestNetworkConfirmation` flag from `isConnected`, simplifying the API.
- Changed `close` from `async` to synchronous, improving clarity and ensuring immediate execution.
- Fixed reconnection issues by improving error handling during interval pings and ensuring proper cleanup of resources.
- Updated documentation and tests to reflect API changes.
- Bumped package version to 0.4.0 to reflect breaking changes.