### PR TITLE
Release v1.0.0: migrate Explorer to bitcoinjs-lib v7 and descriptors v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@bitcoinerlab/explorer",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/explorer",
-      "version": "0.4.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/electrum-client": "^1.0.4",
-        "bitcoinjs-lib": "^6.1.7"
+        "bitcoinjs-lib": "^7.0.1"
       },
       "devDependencies": {
         "@bitcoinerlab/configs": "^2.0.0",
-        "@bitcoinerlab/descriptors": "^2.3.4",
+        "@bitcoinerlab/descriptors": "^3.0.2",
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "bip39": "^3.1.0",
         "regtest-client": "^0.2.1"
@@ -560,25 +560,25 @@
       }
     },
     "node_modules/@bitcoinerlab/descriptors": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.3.4.tgz",
-      "integrity": "sha512-6AxmdduM28PnqeBweZ/3QXzx6iIw+Rz3ET89M6pAtNsW1NtLirEHRADXXY2ALKDni3Co6gwxxRqlqPMoQ3lFBQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-3.0.2.tgz",
+      "integrity": "sha512-qU8BqHF4t8/PV3jRWfxH+wobkK0cirsDCMmhyFPU0ttwVEDEsWB9IsbmYR7K3nZihFWbPx2E4zz0iHLD1Kf8aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/miniscript": "^1.4.3",
+        "@bitcoinerlab/miniscript": "^2.0.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
-        "bip32": "^4.0.0",
-        "bitcoinjs-lib": "^6.1.7",
-        "ecpair": "^2.1.0",
+        "bip32": "github:bitcoinjs/bip32#9e4471ddad38c2d344c1167048072f1c569a115e",
+        "bitcoinjs-lib": "^7.0.1",
+        "ecpair": "^3.0.1",
         "lodash.memoize": "^4.1.2",
-        "varuint-bitcoin": "^1.1.2"
+        "varuint-bitcoin": "^2.0.0"
       },
       "peerDependencies": {
-        "ledger-bitcoin": "^0.2.2"
+        "@ledgerhq/ledger-bitcoin": "^0.3.0"
       },
       "peerDependenciesMeta": {
-        "ledger-bitcoin": {
+        "@ledgerhq/ledger-bitcoin": {
           "optional": true
         }
       }
@@ -593,9 +593,9 @@
       }
     },
     "node_modules/@bitcoinerlab/miniscript": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-1.4.3.tgz",
-      "integrity": "sha512-gf7WK4dKJJJl+IgLGmkTOxXQLiCje9c9y4wTLC+cyt0tBDTiSXgsG0X8FFaXf4d+34b8B5p/EJGvRd7mEYB6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-2.0.0.tgz",
+      "integrity": "sha512-P8yyubPf6lphmIZfyD/ZbhT/umJX7zH1mKjGql7z0Qt+xuffnz2AueQqq2/01VE2rTIq80VM0oRFdJClGBYx/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2664,9 +2664,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2686,28 +2686,42 @@
       "license": "MIT"
     },
     "node_modules/bip174": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
-      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-3.0.0.tgz",
+      "integrity": "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bip174/node_modules/uint8array-tools": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
+      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/bip32": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
-      "integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
+      "version": "5.0.1",
+      "resolved": "git+ssh://git@github.com/bitcoinjs/bip32.git#9e4471ddad38c2d344c1167048072f1c569a115e",
+      "integrity": "sha512-PWlHIAgYCfVhwqNpZyeakHXuLAGyN6rEQZnhxHxKI3BoFJRVWLl26455fhRlHsmbYcV986HqtPnt33Edu5sTCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "@scure/base": "^1.1.1",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/bip39": {
@@ -2731,20 +2745,30 @@
       }
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
-      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-7.0.1.tgz",
+      "integrity": "sha512-vwEmpL5Tpj0I0RBdNkcDMXePoaYSTeKY6mL6/l5esbnTs+jGdPDuLp4NY1hSh6Zk5wSgePygZ4Wx5JJao30Pww==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
+        "bip174": "^3.0.0",
+        "bs58check": "^4.0.0",
+        "uint8array-tools": "^0.0.9",
+        "valibot": "^1.2.0",
+        "varuint-bitcoin": "^2.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/uint8array-tools": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
+      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2805,22 +2829,22 @@
       }
     },
     "node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "license": "MIT",
       "dependencies": {
-        "base-x": "^4.0.0"
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/bs58check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
-      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/bser": {
@@ -3359,18 +3383,18 @@
       "license": "MIT"
     },
     "node_modules/ecpair": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-2.1.0.tgz",
-      "integrity": "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-3.0.1.tgz",
+      "integrity": "sha512-uz8wMFvtdr58TLrXnAesBsoMEyY8UudLOfApcyg40XfZjP+gt1xO4cuZSIkZ8hTMTQ8+ETgt7xSIV4eM7M6VNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "randombytes": "^2.1.0",
-        "typeforce": "^1.18.0",
-        "wif": "^2.0.6"
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -7137,6 +7161,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8064,17 +8089,11 @@
         "typedoc": "^0.28.1"
       }
     },
-    "node_modules/typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8090,6 +8109,15 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -8215,13 +8243,27 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/varuint-bitcoin": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.1.1"
+        "uint8array-tools": "^0.0.8"
       }
     },
     "node_modules/walker": {
@@ -8340,45 +8382,13 @@
       }
     },
     "node_modules/wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bs58check": "<3.0.0"
-      }
-    },
-    "node_modules/wif/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/wif/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/wif/node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
+        "bs58check": "^4.0.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/explorer",
   "description": "Bitcoin Blockchain Explorer: Client Interface featuring Esplora and Electrum Implementations.",
   "homepage": "https://github.com/bitcoinerlab/explorer",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",
@@ -43,13 +43,13 @@
   ],
   "devDependencies": {
     "@bitcoinerlab/configs": "^2.0.0",
-    "@bitcoinerlab/descriptors": "^2.3.4",
+    "@bitcoinerlab/descriptors": "^3.0.2",
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "bip39": "^3.1.0",
     "regtest-client": "^0.2.1"
   },
   "dependencies": {
     "@bitcoinerlab/electrum-client": "^1.0.4",
-    "bitcoinjs-lib": "^6.1.7"
+    "bitcoinjs-lib": "^7.0.1"
   }
 }

--- a/src/address.ts
+++ b/src/address.ts
@@ -1,12 +1,14 @@
 //https://github.com/bitcoinjs/bitcoinjs-lib/issues/990
 //https://electrumx.readthedocs.io/en/latest/protocol-basics.html#script-hashes
 import { address as bjsAddress, crypto, Network } from 'bitcoinjs-lib';
+import { fromHex, toHex } from 'uint8array-tools';
+
 export function addressToScriptHash(address: string, network: Network): string {
   try {
     const scriptPubKey = bjsAddress.toOutputScript(address, network);
-    const scriptHash = Buffer.from(crypto.sha256(scriptPubKey))
-      .reverse()
-      .toString('hex');
+    const scriptHash = toHex(
+      Uint8Array.from(crypto.sha256(scriptPubKey)).reverse()
+    );
     return scriptHash;
   } catch (error) {
     throw new Error(
@@ -23,7 +25,6 @@ export function addressToScriptHash(address: string, network: Network): string {
 export function reverseScriptHash(
   scriptHash: string | undefined
 ): string | undefined {
-  if (scriptHash)
-    return Buffer.from(scriptHash, 'hex').reverse().toString('hex');
-  else return;
+  if (!scriptHash) return;
+  return toHex(fromHex(scriptHash).reverse());
 }

--- a/src/electrum.ts
+++ b/src/electrum.ts
@@ -52,24 +52,35 @@ function getErrorMsg(error: unknown): string {
   }
 }
 
+function isNetwork(network: Network, reference: Network): boolean {
+  return (
+    network.bech32 === reference.bech32 &&
+    network.bip32.public === reference.bip32.public &&
+    network.bip32.private === reference.bip32.private &&
+    network.pubKeyHash === reference.pubKeyHash &&
+    network.scriptHash === reference.scriptHash &&
+    network.wif === reference.wif
+  );
+}
+
 function defaultElectrumServer(network: Network = networks.bitcoin): {
   host: string;
   port: number;
   protocol: 'ssl' | 'tcp';
 } {
-  if (network === networks.bitcoin) {
+  if (isNetwork(network, networks.bitcoin)) {
     return {
       host: ELECTRUM_BLOCKSTREAM_HOST,
       port: ELECTRUM_BLOCKSTREAM_PORT,
       protocol: ELECTRUM_BLOCKSTREAM_PROTOCOL
     };
-  } else if (network === networks.testnet) {
+  } else if (isNetwork(network, networks.testnet)) {
     return {
       host: ELECTRUM_BLOCKSTREAM_TESTNET_HOST,
       port: ELECTRUM_BLOCKSTREAM_TESTNET_PORT,
       protocol: ELECTRUM_BLOCKSTREAM_TESTNET_PROTOCOL
     };
-  } else if (network === networks.regtest) {
+  } else if (isNetwork(network, networks.regtest)) {
     return {
       host: ELECTRUM_LOCAL_REGTEST_HOST,
       port: ELECTRUM_LOCAL_REGTEST_PORT,
@@ -292,8 +303,7 @@ export class ElectrumExplorer implements Explorer {
     let blockStatus = this.#blockStatusMap.get(blockHeight);
     if (blockStatus && blockStatus.irreversible) return blockStatus;
 
-    const headerBuffer = Buffer.from(headerHex, 'hex');
-    const header = Block.fromBuffer(headerBuffer);
+    const header = Block.fromHex(headerHex);
 
     const blockHash = header.getId();
     const blockTime = header.timestamp;


### PR DESCRIPTION
This PR marks the `@bitcoinerlab/explorer` 1.0.0 release and aligns the package with the current bitcoinerlab stack. The goal is to keep Explorer in sync with the same bjs7 direction adopted in `descriptors`, while cleaning up older internals that were still tied to Buffer-based handling.

The dependency upgrade is the core of this change: Explorer now targets `bitcoinjs-lib@7` and `@bitcoinerlab/descriptors@3`. Alongside that, the codebase was updated to follow `Uint8Array`-first patterns, using `uint8array-tools` for hex conversions so Buffer is no longer used in TypeScript sources. Electrum network resolution was also hardened by switching from object-identity checks to value-based network matching, which makes cloned network objects behave as expected when picking default servers.

The integration tests were migrated to the new descriptors API to reflect the same runtime contract we now depend on.

This is a breaking release by design. While Explorer’s high-level fetch/push interface remains stable, projects that share transaction-building/signing flows with Explorer or pin older versions of the Bitcoin JS stack should expect migration work. In particular, consumers moving from the previous stack should account for descriptors v3 API changes and `bitcoinjs-lib@7` conventions around `bigint` values and `Uint8Array` handling.